### PR TITLE
Create package json to allow npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "framework7-sass",
+  "version": "1.4.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/skords/framework7-sass.git"
+  },
+  "description": " This is a simple and basic port of framework7 LESS to SASS"
+}


### PR DESCRIPTION
this will allow to install via npm
Tested with: `npm install freefri/framework7-sass --save-dev`